### PR TITLE
Make sure we have a valid host in norm_netloc().

### DIFF
--- a/test_urlnorm.py
+++ b/test_urlnorm.py
@@ -71,6 +71,7 @@ def pytest_generate_tests(metafunc):
         for url in [
             '-',
             'asdf',
+            'http://./',
             'HTTP://4294967297/test', # one more than max ip > int
             'http://[img]http://i790.photobucket.com/albums/yy185/zack-32009/jordan.jpg[/IMG]',
             ]:

--- a/urlnorm.py
+++ b/urlnorm.py
@@ -208,6 +208,10 @@ def norm_netloc(scheme, netloc):
     if host[-1] == '.':
         host = host[:-1]
 
+    # bracket check is for ipv6 hosts
+    if not host or ('.' not in host and not (host[0] == '[' and host[-1] == ']')):
+        raise InvalidUrl('host %r is not valid' % host)
+
     authority = lower(host)
     if 'xn--' in authority:
         subdomains = [_idn(subdomain) for subdomain in authority.split('.')]


### PR DESCRIPTION
Previously, if we started with a URL like `http://./`, the code in
norm_netloc() would start with a host string of '.', strip the dot,
and then run into an IndexError when it attempted to look for IPv6
brackets.
