### PR TITLE
Fix _idn for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 # also update in urlnorm.py
-version = '1.1.2.pinterest4'
+version = '1.1.2.pinterest5'
 
 setup(name='urlnorm',
         version=version,

--- a/test_urlnorm.py
+++ b/test_urlnorm.py
@@ -57,6 +57,7 @@ def pytest_generate_tests(metafunc):
             'homefeedapps://pinterest/': 'homefeedapps://pinterest/', # can handle Android deep link
             'mailto:me@pinterest.com': 'mailto:me@pinterest.com', # can handle mailto:
             "itms://itunes.apple.com/us/app/touch-pets-cats/id379475816?mt=8#23161525,,1293732683083,260430,tw" : "itms://itunes.apple.com/us/app/touch-pets-cats/id379475816?mt=8#23161525,,1293732683083,260430,tw", #can handle itms://
+            'http://www.xn--iod-dma.com': u'http://www.iod\xe9.com/'
 
         }
         for bad, good in tests.items():

--- a/urlnorm.py
+++ b/urlnorm.py
@@ -240,7 +240,7 @@ def norm_netloc(scheme, netloc):
 def _idn(subdomain):
     if subdomain.startswith('xn--'):
         try:
-            subdomain = subdomain.decode('idna')
+            subdomain = subdomain.encode().decode('idna')
         except UnicodeError:
             raise InvalidUrl('Error converting subdomain %r to IDN' % subdomain)
     return subdomain


### PR DESCRIPTION
Previously got `AttributeError: 'str' object has no attribute 'decode'

And add unit test